### PR TITLE
Add Playwright POM test suite

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,11 @@ Thumbs.db
 
 # Linux specific files
 *~
+
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-icons": "^5.4.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -457,6 +458,23 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -3578,6 +3596,53 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "lint": "next lint"
   },
   "dependencies": {
@@ -18,6 +20,7 @@
     "react-icons": "^5.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,79 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests/specs',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('')`. */
+    baseURL: 'https://playground-drab-six.vercel.app/',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://localhost:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});

--- a/tests/data/characters.ts
+++ b/tests/data/characters.ts
@@ -1,0 +1,27 @@
+export type Character = {
+  id: string;
+  name: string;
+  house: string;
+  dateOfBirth: string;
+  actor: string;
+  image: string;
+};
+
+export const charactersApiUrl = 'https://hp-api.onrender.com/api/characters';
+
+export const characterScenarios = [
+  { index: 0, name: 'Harry Potter' },
+  { index: 1, name: 'Hermione Granger' },
+  { index: 2, name: 'Ron Weasley' },
+  { index: 3, name: 'Draco Malfoy' },
+  { index: 4, name: 'Minerva McGonagall' },
+  { index: 5, name: 'Cedric Diggory' },
+  { index: 6, name: 'Cho Chang' },
+  { index: 7, name: 'Severus Snape' },
+  { index: 8, name: 'Rubeus Hagrid' },
+  { index: 9, name: 'Neville Longbottom' },
+];
+
+export function normalizeCharacterName(name: string) {
+  return name.replace(/[^a-zA-Z0-9]/g, '');
+}

--- a/tests/data/formData.ts
+++ b/tests/data/formData.ts
@@ -1,0 +1,57 @@
+export type Gender = 'male' | 'female' | 'other';
+
+export type Hobby =
+  | 'Read books'
+  | 'Travel'
+  | 'Video Games'
+  | 'Sports'
+  | 'Movies'
+  | 'Board Games';
+
+export type RegistrationFormData = {
+  scenario: string;
+  name: string;
+  email: string;
+  password: string;
+  country: string;
+  gender: Gender;
+  hobbies: Hobby[];
+};
+
+export const validRegistrationForms: RegistrationFormData[] = [
+  {
+    scenario: 'Brazil male with books and sports',
+    name: 'Bruno Silva',
+    email: 'bruno.silva@example.com',
+    password: 'Password123',
+    country: 'Brazil',
+    gender: 'male',
+    hobbies: ['Read books', 'Sports'],
+  },
+  {
+    scenario: 'Portugal female with travel and movies',
+    name: 'Ana Costa',
+    email: 'ana.costa@example.com',
+    password: 'Password123',
+    country: 'Portugal',
+    gender: 'female',
+    hobbies: ['Travel', 'Movies'],
+  },
+  {
+    scenario: 'Canada other with games',
+    name: 'Alex Morgan',
+    email: 'alex.morgan@example.com',
+    password: 'Password123',
+    country: 'Canada',
+    gender: 'other',
+    hobbies: ['Video Games', 'Board Games'],
+  },
+];
+
+export const requiredFieldMessages = [
+  'The name field is required.',
+  'The email field is required.',
+  'The password field is required.',
+  'The country field is required.',
+  'The gender field is required.',
+];

--- a/tests/data/products.ts
+++ b/tests/data/products.ts
@@ -1,0 +1,92 @@
+export const products = {
+  lightsaber: {
+    index: 0,
+    name: 'Lightsaber (Star Wars)',
+    price: '9999.99',
+    initialQuantity: 2,
+    quantityAfterAddingOne: '1 units',
+  },
+  rubberDuck: {
+    index: 1,
+    name: 'Giant Rubber Duck',
+    price: '49.99',
+    initialQuantity: 15,
+    quantityAfterAddingOne: '14 units',
+  },
+  sharkRepellent: {
+    index: 2,
+    name: 'Shark Repellent',
+    price: '299.99',
+    initialQuantity: 5,
+    quantityAfterAddingOne: '4 units',
+  },
+  sonicScrewdriver: {
+    index: 4,
+    name: 'Sonic Screwdriver (Doctor Who)',
+    price: '79.99',
+    initialQuantity: 7,
+    quantityAfterAddingOne: '6 units',
+  },
+  baconCandle: {
+    index: 5,
+    name: 'Bacon-Scented Candle',
+    price: '14.99',
+    initialQuantity: 20,
+    quantityAfterAddingOne: '19 units',
+  },
+  dogSunglasses: {
+    index: 7,
+    name: 'Dog Sunglasses',
+    price: '24.99',
+    initialQuantity: 12,
+    quantityAfterAddingOne: '11 units',
+  },
+};
+
+export const paymentMethods = {
+  mbWay: 'MBWay',
+  klarna: 'Klarna',
+  multibanco: 'Multibanco',
+  paypal: 'PayPal',
+  visa: 'Visa',
+};
+
+export const newProduct = {
+  name: 'Automation Course Voucher',
+  price: '149.90',
+  quantity: '3',
+  quantityAfterAddingOne: '2 units',
+};
+
+export const checkoutScenarios = [
+  {
+    scenario: 'MBWay payment with one product',
+    products: [products.rubberDuck],
+    paymentMethod: paymentMethods.mbWay,
+    expectedTotal: '49.99',
+  },
+  {
+    scenario: 'Klarna payment with two products',
+    products: [products.rubberDuck, products.sharkRepellent],
+    paymentMethod: paymentMethods.klarna,
+    expectedTotal: '349.98',
+  },
+  {
+    scenario: 'Multibanco payment with one product',
+    products: [products.sonicScrewdriver],
+    paymentMethod: paymentMethods.multibanco,
+    expectedTotal: '79.99',
+  },
+  {
+    scenario: 'PayPal payment with two products',
+    products: [products.baconCandle, products.dogSunglasses],
+    paymentMethod: paymentMethods.paypal,
+    expectedTotal: '39.98',
+  },
+  {
+    scenario: 'Visa payment with one product',
+    products: [products.lightsaber],
+    paymentMethod: paymentMethods.visa,
+    expectedTotal: '9999.99',
+  },
+];

--- a/tests/data/tasks.ts
+++ b/tests/data/tasks.ts
@@ -1,0 +1,6 @@
+export const taskExamples = {
+  firstTask: 'Study Playwright locators',
+  secondTask: 'Create Page Objects',
+  editedTask: 'Review Page Objects',
+  emptyTask: '   ',
+};

--- a/tests/data/users.ts
+++ b/tests/data/users.ts
@@ -1,0 +1,19 @@
+export const validUser = {
+  username: 'test',
+  password: 'password123',
+};
+
+export const blockedUser = {
+  username: 'testblock',
+  password: 'password123',
+};
+
+export const invalidUser = {
+  username: 'unknown',
+  password: 'password123',
+};
+
+export const userWithInvalidPassword = {
+  username: 'test',
+  password: 'wrong-password',
+};

--- a/tests/fixtures/test.ts
+++ b/tests/fixtures/test.ts
@@ -1,0 +1,3 @@
+import { test, expect } from '@playwright/test';
+
+export { test, expect };

--- a/tests/pages/FormPage.ts
+++ b/tests/pages/FormPage.ts
@@ -1,0 +1,143 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import type { Gender, Hobby, RegistrationFormData } from '../data/formData';
+
+export class FormPage {
+  readonly page: Page;
+
+  // Fixed locators
+  readonly title: Locator;
+  readonly nameInput: Locator;
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly countrySelect: Locator;
+  readonly submitButton: Locator;
+  readonly successTitle: Locator;
+  readonly successMessage: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    this.title = page.getByRole('heading', { name: 'Form' });
+    this.nameInput = page.getByPlaceholder('Type your name');
+    this.emailInput = page.getByPlaceholder('Type your e-mail');
+    this.passwordInput = page.getByPlaceholder('Type your password');
+    this.countrySelect = page.getByLabel('Country');
+    this.submitButton = page.getByRole('button', { name: 'Send' });
+    this.successTitle = page.getByText('Success!');
+    this.successMessage = page.getByText(
+      'The form has been submitted successfully.'
+    );
+  }
+
+  // Dynamic locators
+  genderOption(gender: Gender): Locator {
+    const genderLabel = {
+      male: 'Male',
+      female: 'Female',
+      other: 'Other',
+    };
+
+    return this.page.getByRole('radio', {
+      name: genderLabel[gender],
+      exact: true,
+    });
+  }
+
+  hobbyOption(hobby: Hobby): Locator {
+    return this.page.getByRole('checkbox', { name: hobby, exact: true });
+  }
+
+  validationMessage(message: string): Locator {
+    return this.page.getByText(message);
+  }
+
+  // Actions
+  async goto() {
+    await test.step('Open the form page', async () => {
+      await this.page.goto('/form');
+    });
+  }
+
+  async fillName(name: string) {
+    await test.step(`Fill name with "${name}"`, async () => {
+      await this.nameInput.fill(name);
+    });
+  }
+
+  async fillEmail(email: string) {
+    await test.step(`Fill email with "${email}"`, async () => {
+      await this.emailInput.fill(email);
+    });
+  }
+
+  async fillPassword(password: string) {
+    await test.step('Fill password', async () => {
+      await this.passwordInput.fill(password);
+    });
+  }
+
+  async selectCountry(country: string) {
+    await test.step(`Select country "${country}"`, async () => {
+      await this.countrySelect.selectOption({ label: country });
+    });
+  }
+
+  async selectGender(gender: Gender) {
+    await test.step(`Select gender "${gender}"`, async () => {
+      await this.genderOption(gender).check();
+    });
+  }
+
+  async selectHobbies(hobbies: Hobby[]) {
+    await test.step(`Select hobbies: ${hobbies.join(', ')}`, async () => {
+      for (const hobby of hobbies) {
+        await this.hobbyOption(hobby).check();
+      }
+    });
+  }
+
+  async submit() {
+    await test.step('Submit the registration form', async () => {
+      await this.submitButton.click();
+    });
+  }
+
+  async fillRegistrationForm(formData: RegistrationFormData) {
+    await test.step(`Fill registration form: ${formData.scenario}`, async () => {
+      await this.fillName(formData.name);
+      await this.fillEmail(formData.email);
+      await this.fillPassword(formData.password);
+      await this.selectCountry(formData.country);
+      await this.selectGender(formData.gender);
+      await this.selectHobbies(formData.hobbies);
+    });
+  }
+
+  // Asserts
+  async expectFormPageVisible() {
+    await test.step('Check that the form page is visible', async () => {
+      await expect(this.title).toBeVisible();
+      await expect(this.nameInput).toBeVisible();
+      await expect(this.emailInput).toBeVisible();
+      await expect(this.passwordInput).toBeVisible();
+      await expect(this.countrySelect).toBeVisible();
+      await expect(this.submitButton).toBeVisible();
+    });
+  }
+
+  async expectSuccessPageVisible() {
+    await test.step('Check that the success page is visible', async () => {
+      await expect(this.page).toHaveURL(/\/submittedform$/);
+      await expect(this.successTitle).toBeVisible();
+      await expect(this.successMessage).toBeVisible();
+    });
+  }
+
+  async expectRequiredFieldMessages(messages: string[]) {
+    await test.step('Check that required field messages are visible', async () => {
+      for (const message of messages) {
+        await expect(this.validationMessage(message)).toBeVisible();
+      }
+    });
+  }
+}

--- a/tests/pages/HomePage.ts
+++ b/tests/pages/HomePage.ts
@@ -1,0 +1,78 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+export class HomePage {
+  readonly page: Page;
+
+  // Fixed locators
+  readonly bannerImage: Locator;
+  readonly introText: Locator;
+  readonly challengesTitle: Locator;
+  readonly loginChallenge: Locator;
+  readonly formsChallenge: Locator;
+  readonly dynamicTableChallenge: Locator;
+  readonly moreChallenges: Locator;
+  readonly loginLink: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    this.bannerImage = page.getByRole('img', {
+      name: 'Bug Buster Mentoring Banner',
+    });
+    this.introText = page.getByText(
+      'This page was developed by the Bug Buster Mentorship team for educational purposes.'
+    );
+    this.challengesTitle = page.getByRole('heading', {
+      name: 'Available Challenges:',
+    });
+    this.loginChallenge = page.getByText('Login', { exact: true });
+    this.formsChallenge = page.getByText('Forms', { exact: true });
+    this.dynamicTableChallenge = page.getByText('Dynamic Table', {
+      exact: true,
+    });
+    this.moreChallenges = page.getByText('And much more!', { exact: true });
+    this.loginLink = page.getByRole('link', { name: 'LOGIN' }).first();
+  }
+
+  // Dynamic locators
+  challengeByName(name: string): Locator {
+    return this.page.getByText(name, { exact: true });
+  }
+
+  // Actions
+  async goto() {
+    await test.step('Open the home page', async () => {
+      await this.page.goto('/');
+    });
+  }
+
+  async clickLoginLink() {
+    await test.step('Click the login link in the main menu', async () => {
+      await this.loginLink.click();
+    });
+  }
+
+  // Asserts
+  async expectHomePageVisible() {
+    await test.step('Check that the home page main content is visible', async () => {
+      await expect(this.bannerImage).toBeVisible();
+      await expect(this.introText).toBeVisible();
+      await expect(this.challengesTitle).toBeVisible();
+    });
+  }
+
+  async expectMainChallengesVisible() {
+    await test.step('Check that the main challenges are visible', async () => {
+      await expect(this.loginChallenge).toBeVisible();
+      await expect(this.formsChallenge).toBeVisible();
+      await expect(this.dynamicTableChallenge).toBeVisible();
+      await expect(this.moreChallenges).toBeVisible();
+    });
+  }
+
+  async expectRedirectedToLogin() {
+    await test.step('Check that the user is redirected to the login page', async () => {
+      await expect(this.page).toHaveURL(/\/login$/);
+    });
+  }
+}

--- a/tests/pages/LoginPage.ts
+++ b/tests/pages/LoginPage.ts
@@ -1,0 +1,120 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+export class LoginPage {
+  readonly page: Page;
+
+  // Fixed locators
+  readonly title: Locator;
+  readonly usernameInput: Locator;
+  readonly passwordInput: Locator;
+  readonly loginButton: Locator;
+  readonly successMessage: Locator;
+  readonly blockedMessage: Locator;
+  readonly notFoundMessage: Locator;
+  readonly invalidPasswordMessage: Locator;
+  readonly temporaryBlockedMessage: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    this.title = page.getByRole('heading', { name: 'Login' });
+    this.usernameInput = page.getByPlaceholder('Type your username');
+    this.passwordInput = page.getByPlaceholder('Type your password');
+    this.loginButton = page.getByRole('button', { name: 'Login' });
+    this.successMessage = page.getByText(
+      'User successfully logged in! Redirecting...'
+    );
+    this.blockedMessage = page.getByText('User blocked!');
+    this.notFoundMessage = page.getByText('User not found!');
+    this.invalidPasswordMessage = page.getByText(
+      'Incorrect username or password!'
+    );
+    this.temporaryBlockedMessage = page.getByText(
+      'User temporarily blocked!'
+    );
+  }
+
+  // Dynamic locators
+  statusMessageByText(message: string): Locator {
+    return this.page.getByText(message);
+  }
+
+  // Actions
+  async goto() {
+    await test.step('Open the login page', async () => {
+      await this.page.goto('/login');
+    });
+  }
+
+  async fillUsername(username: string) {
+    await test.step(`Fill username with "${username}"`, async () => {
+      await this.usernameInput.fill(username);
+    });
+  }
+
+  async fillPassword(password: string) {
+    await test.step('Fill password', async () => {
+      await this.passwordInput.fill(password);
+    });
+  }
+
+  async submit() {
+    await test.step('Submit the login form', async () => {
+      await this.loginButton.click();
+    });
+  }
+
+  async login(username: string, password: string) {
+    await test.step(`Login with username "${username}"`, async () => {
+      await this.fillUsername(username);
+      await this.fillPassword(password);
+      await this.submit();
+    });
+  }
+
+  // Asserts
+  async expectLoginPageVisible() {
+    await test.step('Check that the login form is visible', async () => {
+      await expect(this.title).toBeVisible();
+      await expect(this.usernameInput).toBeVisible();
+      await expect(this.passwordInput).toBeVisible();
+      await expect(this.loginButton).toBeVisible();
+    });
+  }
+
+  async expectSuccessfulLoginMessage() {
+    await test.step('Check that the successful login message is visible', async () => {
+      await expect(this.successMessage).toBeVisible();
+    });
+  }
+
+  async expectBlockedUserMessage() {
+    await test.step('Check that the blocked user message is visible', async () => {
+      await expect(this.blockedMessage).toBeVisible();
+    });
+  }
+
+  async expectUserNotFoundMessage() {
+    await test.step('Check that the user not found message is visible', async () => {
+      await expect(this.notFoundMessage).toBeVisible();
+    });
+  }
+
+  async expectInvalidPasswordMessage() {
+    await test.step('Check that the wrong password message is visible', async () => {
+      await expect(this.invalidPasswordMessage).toBeVisible();
+    });
+  }
+
+  async expectTemporaryBlockedMessage() {
+    await test.step('Check that the temporary block message is visible', async () => {
+      await expect(this.temporaryBlockedMessage).toBeVisible();
+    });
+  }
+
+  async expectRedirectedToDashboard() {
+    await test.step('Check that the user is redirected to the dashboard', async () => {
+      await expect(this.page).toHaveURL(/\/dashboard$/);
+    });
+  }
+}

--- a/tests/pages/StorePage.ts
+++ b/tests/pages/StorePage.ts
@@ -1,0 +1,340 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+export class StorePage {
+  readonly page: Page;
+
+  // Fixed locators
+  readonly storePage: Locator;
+  readonly inventoryTab: Locator;
+  readonly catalogTab: Locator;
+  readonly cartTab: Locator;
+  readonly paymentsTab: Locator;
+  readonly ordersTab: Locator;
+  readonly catalogTitle: Locator;
+  readonly cartTitle: Locator;
+  readonly paymentTitle: Locator;
+  readonly ordersTitle: Locator;
+  readonly inventoryTitle: Locator;
+  readonly inventoryNameInput: Locator;
+  readonly inventoryPriceInput: Locator;
+  readonly inventoryQuantityInput: Locator;
+  readonly inventorySubmitButton: Locator;
+  readonly cartEmptyMessage: Locator;
+  readonly paymentEmptyMessage: Locator;
+  readonly cartTotalValue: Locator;
+  readonly goToPaymentButton: Locator;
+  readonly confirmPaymentButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    this.storePage = page.getByTestId('store-page');
+    this.inventoryTab = page.getByTestId('store-tab-inventory');
+    this.catalogTab = page.getByTestId('store-tab-catalog');
+    this.cartTab = page.getByTestId('store-tab-cart');
+    this.paymentsTab = page.getByTestId('store-tab-payments');
+    this.ordersTab = page.getByTestId('store-tab-orders');
+    this.catalogTitle = page.getByTestId('catalog-title');
+    this.cartTitle = page.getByTestId('cart-title');
+    this.paymentTitle = page.getByTestId('payment-title');
+    this.ordersTitle = page.getByTestId('orders-title');
+    this.inventoryTitle = page.getByTestId('inventory-title');
+    this.inventoryNameInput = page.getByTestId('inventory-input-name');
+    this.inventoryPriceInput = page.getByTestId('inventory-input-price');
+    this.inventoryQuantityInput = page.getByTestId('inventory-input-quantity');
+    this.inventorySubmitButton = page.getByTestId('inventory-submit-button');
+    this.cartEmptyMessage = page.getByTestId('cart-empty-message');
+    this.paymentEmptyMessage = page.getByTestId('payment-empty-message');
+    this.cartTotalValue = page.getByTestId('cart-total-value');
+    this.goToPaymentButton = page.getByTestId('cart-go-to-payment');
+    this.confirmPaymentButton = page.getByTestId('payment-confirm-button');
+  }
+
+  // Dynamic locators
+  catalogProductNameByIndex(index: number): Locator {
+    return this.page.getByTestId(`catalog-item-name-${index}`);
+  }
+
+  catalogProductQuantityByIndex(index: number): Locator {
+    return this.page.getByTestId(`catalog-item-quantity-${index}`);
+  }
+
+  catalogAddButtonByIndex(index: number): Locator {
+    return this.page.getByTestId(`catalog-item-add-button-${index}`);
+  }
+
+  catalogProductNameByText(productName: string): Locator {
+    return this.page.getByText(productName, { exact: true });
+  }
+
+  catalogProductItemByText(productName: string): Locator {
+    return this.catalogProductNameByText(productName).locator('..').locator('..');
+  }
+
+  catalogProductQuantityByText(productName: string): Locator {
+    return this.catalogProductItemByText(productName).locator(
+      '[data-testid^="catalog-item-quantity-"]'
+    );
+  }
+
+  catalogAddButtonByProductName(productName: string): Locator {
+    return this.catalogProductItemByText(productName).getByRole('button', {
+      name: 'Add to Cart',
+    });
+  }
+
+  cartProductNameByIndex(index: number): Locator {
+    return this.page.getByTestId(`cart-item-name-${index}`);
+  }
+
+  cartProductQuantityByIndex(index: number): Locator {
+    return this.page.getByTestId(`cart-item-quantity-${index}`);
+  }
+
+  cartProductTotalByIndex(index: number): Locator {
+    return this.page.getByTestId(`cart-item-total-value-${index}`);
+  }
+
+  paymentMethodByName(paymentMethod: string): Locator {
+    return this.page.getByTestId(`payment-method-input-${paymentMethod}`);
+  }
+
+  orderByIndex(index: number): Locator {
+    return this.page.getByTestId(`order-${index}`);
+  }
+
+  orderPaymentByIndex(index: number): Locator {
+    return this.page.getByTestId(`order-payment-${index}`);
+  }
+
+  orderProductNameByIndex(orderIndex: number, productIndex: number): Locator {
+    return this.page.getByTestId(
+      `order-item-name-${orderIndex}-${productIndex}`
+    );
+  }
+
+  orderTotalByIndex(index: number): Locator {
+    return this.page.getByTestId(`order-total-value-${index}`);
+  }
+
+  // Actions
+  async goto() {
+    await test.step('Open the store page', async () => {
+      await this.page.goto('/store');
+    });
+  }
+
+  async openCatalog() {
+    await test.step('Open the product catalog', async () => {
+      await this.catalogTab.click();
+    });
+  }
+
+  async openInventory() {
+    await test.step('Open the inventory page', async () => {
+      await this.inventoryTab.click();
+    });
+  }
+
+  async openCart() {
+    await test.step('Open the cart', async () => {
+      await this.cartTab.click();
+    });
+  }
+
+  async openPayments() {
+    await test.step('Open the payments page', async () => {
+      await this.paymentsTab.click();
+    });
+  }
+
+  async openOrders() {
+    await test.step('Open the orders page', async () => {
+      await this.ordersTab.click();
+    });
+  }
+
+  async addProductToCart(productIndex: number) {
+    await test.step(`Add product ${productIndex} to cart`, async () => {
+      await this.catalogAddButtonByIndex(productIndex).click();
+    });
+  }
+
+  async addProductToCartByName(productName: string) {
+    await test.step(`Add product "${productName}" to cart`, async () => {
+      await this.catalogAddButtonByProductName(productName).click();
+    });
+  }
+
+  async fillNewProduct(name: string, price: string, quantity: string) {
+    await test.step(`Fill new product "${name}"`, async () => {
+      await this.inventoryNameInput.fill(name);
+      await this.inventoryPriceInput.fill(price);
+      await this.inventoryQuantityInput.fill(quantity);
+    });
+  }
+
+  async submitNewProduct() {
+    await test.step('Submit new product', async () => {
+      await this.inventorySubmitButton.click();
+    });
+  }
+
+  async createProduct(name: string, price: string, quantity: string) {
+    await test.step(`Create product "${name}"`, async () => {
+      await this.fillNewProduct(name, price, quantity);
+      await this.submitNewProduct();
+    });
+  }
+
+  async goToPayment() {
+    await test.step('Go from cart to payment', async () => {
+      await this.goToPaymentButton.click();
+    });
+  }
+
+  async selectPaymentMethod(paymentMethod: string) {
+    await test.step(`Select payment method "${paymentMethod}"`, async () => {
+      await this.paymentMethodByName(paymentMethod).check();
+    });
+  }
+
+  async confirmPayment() {
+    await test.step('Confirm payment', async () => {
+      await this.confirmPaymentButton.click();
+    });
+  }
+
+  // Asserts
+  async expectStorePageVisible() {
+    await test.step('Check that the store page is visible', async () => {
+      await expect(this.storePage).toBeVisible();
+    });
+  }
+
+  async expectCatalogVisible() {
+    await test.step('Check that the catalog is visible', async () => {
+      await expect(this.catalogTitle).toBeVisible();
+    });
+  }
+
+  async expectInventoryVisible() {
+    await test.step('Check that the inventory page is visible', async () => {
+      await expect(this.inventoryTitle).toBeVisible();
+      await expect(this.inventoryNameInput).toBeVisible();
+      await expect(this.inventoryPriceInput).toBeVisible();
+      await expect(this.inventoryQuantityInput).toBeVisible();
+      await expect(this.inventorySubmitButton).toBeVisible();
+    });
+  }
+
+  async expectCartVisible() {
+    await test.step('Check that the cart is visible', async () => {
+      await expect(this.cartTitle).toBeVisible();
+    });
+  }
+
+  async expectPaymentVisible() {
+    await test.step('Check that the payment page is visible', async () => {
+      await expect(this.paymentTitle).toBeVisible();
+    });
+  }
+
+  async expectOrdersVisible() {
+    await test.step('Check that the orders page is visible', async () => {
+      await expect(this.ordersTitle).toBeVisible();
+    });
+  }
+
+  async expectCatalogProductVisible(index: number, productName: string) {
+    await test.step(`Check that catalog product "${productName}" is visible`, async () => {
+      await expect(this.catalogProductNameByIndex(index)).toHaveText(
+        productName
+      );
+    });
+  }
+
+  async expectCatalogProductQuantity(index: number, quantityText: string) {
+    await test.step(`Check product ${index} quantity in catalog`, async () => {
+      await expect(this.catalogProductQuantityByIndex(index)).toHaveText(
+        quantityText
+      );
+    });
+  }
+
+  async expectCatalogProductVisibleByName(productName: string) {
+    await test.step(`Check that catalog product "${productName}" is visible`, async () => {
+      await expect(this.catalogProductNameByText(productName)).toBeVisible();
+    });
+  }
+
+  async expectCatalogProductQuantityByName(
+    productName: string,
+    quantityText: string
+  ) {
+    await test.step(`Check product "${productName}" quantity in catalog`, async () => {
+      await expect(this.catalogProductQuantityByText(productName)).toHaveText(
+        quantityText
+      );
+    });
+  }
+
+  async expectProductInCart(
+    index: number,
+    productName: string,
+    quantity: string,
+    total: string
+  ) {
+    await test.step(`Check that "${productName}" is in the cart`, async () => {
+      await expect(this.cartProductNameByIndex(index)).toHaveText(productName);
+      await expect(this.cartProductQuantityByIndex(index)).toHaveText(quantity);
+      await expect(this.cartProductTotalByIndex(index)).toHaveText(total);
+    });
+  }
+
+  async expectCartTotal(total: string) {
+    await test.step(`Check cart total is "${total}"`, async () => {
+      await expect(this.cartTotalValue).toHaveText(total);
+    });
+  }
+
+  async expectCartEmptyMessage() {
+    await test.step('Check that the cart empty message is visible', async () => {
+      await expect(this.cartEmptyMessage).toBeVisible();
+    });
+  }
+
+  async expectPaymentEmptyMessage() {
+    await test.step('Check that the payment empty message is visible', async () => {
+      await expect(this.paymentEmptyMessage).toBeVisible();
+    });
+  }
+
+  async expectPaymentMethodSelected(paymentMethod: string) {
+    await test.step(`Check payment method "${paymentMethod}" is selected`, async () => {
+      await expect(this.paymentMethodByName(paymentMethod)).toBeChecked();
+    });
+  }
+
+  async expectOrderCreated(
+    orderIndex: number,
+    products: Array<{ name: string }>,
+    paymentMethod: string,
+    total: string
+  ) {
+    await test.step('Check that the order was created', async () => {
+      await expect(this.orderByIndex(orderIndex)).toBeVisible();
+
+      for (const [productIndex, product] of products.entries()) {
+        await expect(
+          this.orderProductNameByIndex(orderIndex, productIndex)
+        ).toContainText(product.name);
+      }
+
+      await expect(this.orderPaymentByIndex(orderIndex)).toContainText(
+        paymentMethod
+      );
+      await expect(this.orderTotalByIndex(orderIndex)).toHaveText(total);
+    });
+  }
+}

--- a/tests/pages/StorePage.ts
+++ b/tests/pages/StorePage.ts
@@ -325,7 +325,9 @@ export class StorePage {
     await test.step('Check that the order was created', async () => {
       await expect(this.orderByIndex(orderIndex)).toBeVisible();
 
-      for (const [productIndex, product] of products.entries()) {
+      for (let productIndex = 0; productIndex < products.length; productIndex++) {
+        const product = products[productIndex];
+
         await expect(
           this.orderProductNameByIndex(orderIndex, productIndex)
         ).toContainText(product.name);

--- a/tests/pages/TablePage.ts
+++ b/tests/pages/TablePage.ts
@@ -1,0 +1,115 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import type { Character } from '../data/characters';
+import { normalizeCharacterName } from '../data/characters';
+
+export class TablePage {
+  readonly page: Page;
+
+  // Fixed locators
+  readonly characterTable: Locator;
+  readonly imageColumnHeader: Locator;
+  readonly nameColumnHeader: Locator;
+  readonly houseColumnHeader: Locator;
+  readonly dateOfBirthColumnHeader: Locator;
+  readonly actorColumnHeader: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    this.characterTable = page.locator('#characterTable');
+    this.imageColumnHeader = page.getByRole('columnheader', { name: 'Image' });
+    this.nameColumnHeader = page.getByRole('columnheader', { name: 'Name' });
+    this.houseColumnHeader = page.getByRole('columnheader', { name: 'House' });
+    this.dateOfBirthColumnHeader = page.getByRole('columnheader', {
+      name: 'Date of Birth',
+    });
+    this.actorColumnHeader = page.getByRole('columnheader', { name: 'Actor' });
+  }
+
+  // Dynamic locators
+  characterRowByName(name: string): Locator {
+    return this.page.locator(`#characterRow${normalizeCharacterName(name)}`);
+  }
+
+  characterNameByName(name: string): Locator {
+    const normalizedName = normalizeCharacterName(name);
+    return this.page.locator(`#tableCharacterName${normalizedName}`);
+  }
+
+  characterHouseByName(name: string): Locator {
+    const normalizedName = normalizeCharacterName(name);
+    return this.page.locator(`#tableCharacterHouse${normalizedName}`);
+  }
+
+  characterDateOfBirthByName(name: string): Locator {
+    const normalizedName = normalizeCharacterName(name);
+    return this.page.locator(`#tableCharacterDateOfBirth${normalizedName}`);
+  }
+
+  characterActorByName(name: string): Locator {
+    const normalizedName = normalizeCharacterName(name);
+    return this.page.locator(`#tableCharacterActor${normalizedName}`);
+  }
+
+  // Actions
+  async goto() {
+    await test.step('Open the character table page', async () => {
+      await this.page.goto('/table');
+    });
+  }
+
+  // Asserts
+  async expectTableVisible() {
+    await test.step('Check that the character table is visible', async () => {
+      await expect(this.characterTable).toBeVisible();
+    });
+  }
+
+  async expectMainColumnsVisible() {
+    await test.step('Check that the main table columns are visible', async () => {
+      await expect(this.imageColumnHeader).toBeVisible();
+      await expect(this.nameColumnHeader).toBeVisible();
+      await expect(this.houseColumnHeader).toBeVisible();
+      await expect(this.dateOfBirthColumnHeader).toBeVisible();
+      await expect(this.actorColumnHeader).toBeVisible();
+    });
+  }
+
+  async expectCharacterVisible(character: Character) {
+    await test.step(`Check character "${character.name}" row is visible`, async () => {
+      await expect(this.characterRowByName(character.name)).toBeVisible();
+    });
+
+    await test.step(`Check character "${character.name}" name`, async () => {
+      await expect(this.characterNameByName(character.name)).toHaveText(
+        character.name
+      );
+    });
+
+    await test.step(`Check character "${character.name}" house`, async () => {
+      await expect(this.characterHouseByName(character.name)).toHaveText(
+        character.house
+      );
+    });
+
+    await test.step(`Check character "${character.name}" date of birth`, async () => {
+      await expect(this.characterDateOfBirthByName(character.name)).toHaveText(
+        character.dateOfBirth || 'Unknown'
+      );
+    });
+
+    await test.step(`Check character "${character.name}" actor`, async () => {
+      await expect(this.characterActorByName(character.name)).toHaveText(
+        character.actor
+      );
+    });
+  }
+
+  async expectCharactersFromApiVisible(characters: Character[]) {
+    await test.step('Check that API characters are rendered in the table', async () => {
+      for (const character of characters) {
+        await this.expectCharacterVisible(character);
+      }
+    });
+  }
+}

--- a/tests/pages/TasksPage.ts
+++ b/tests/pages/TasksPage.ts
@@ -1,0 +1,143 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+export class TasksPage {
+  readonly page: Page;
+
+  // Fixed locators
+  readonly title: Locator;
+  readonly taskInput: Locator;
+  readonly addButton: Locator;
+  readonly taskList: Locator;
+  readonly completedTaskList: Locator;
+  readonly completedTasksTitle: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    this.title = page.getByTestId('task-title');
+    this.taskInput = page.getByTestId('task-input');
+    this.addButton = page.getByTestId('task-submit-button');
+    this.taskList = page.locator('#taskList');
+    this.completedTaskList = page.locator('#completedTaskList');
+    this.completedTasksTitle = page.getByRole('heading', {
+      name: 'Completed Tasks',
+    });
+  }
+
+  // Dynamic locators
+  taskItemById(id: number): Locator {
+    return this.page.getByTestId(`todo-item-${id}`);
+  }
+
+  taskTextById(id: number): Locator {
+    return this.page.getByTestId(`todo-item-text-desktop-${id}`);
+  }
+
+  completeButtonById(id: number): Locator {
+    return this.page.getByTestId(`todo-item-complete-button-desktop-${id}`);
+  }
+
+  editInputById(id: number): Locator {
+    return this.page.getByTestId(`todo-item-edit-input-desktop-${id}`);
+  }
+
+  saveButtonById(id: number): Locator {
+    return this.page.getByTestId(`todo-item-save-button-desktop-${id}`);
+  }
+
+  completedTaskById(id: number): Locator {
+    return this.page.getByTestId(`completed-task-${id}`);
+  }
+
+  completedTaskTextById(id: number): Locator {
+    return this.page.getByTestId(`completed-task-text-${id}`);
+  }
+
+  completedTaskStatusById(id: number): Locator {
+    return this.page.getByTestId(`completed-task-status-${id}`);
+  }
+
+  // Actions
+  async goto() {
+    await test.step('Open the tasks page', async () => {
+      await this.page.goto('/tasks');
+    });
+  }
+
+  async fillTask(taskText: string) {
+    await test.step(`Fill task with "${taskText}"`, async () => {
+      await this.taskInput.fill(taskText);
+    });
+  }
+
+  async clickAddButton() {
+    await test.step('Click the add task button', async () => {
+      await this.addButton.click();
+    });
+  }
+
+  async addTask(taskText: string) {
+    await test.step(`Add task "${taskText}"`, async () => {
+      await this.fillTask(taskText);
+      await this.clickAddButton();
+    });
+  }
+
+  async editTask(id: number, newTaskText: string) {
+    await test.step(`Edit task ${id} to "${newTaskText}"`, async () => {
+      await this.taskTextById(id).dblclick();
+      await this.editInputById(id).fill(newTaskText);
+      await this.saveButtonById(id).click();
+    });
+  }
+
+  async completeTask(id: number) {
+    await test.step(`Complete task ${id}`, async () => {
+      await this.completeButtonById(id).click();
+    });
+  }
+
+  // Asserts
+  async expectTasksPageVisible() {
+    await test.step('Check that the tasks page is visible', async () => {
+      await expect(this.title).toBeVisible();
+      await expect(this.taskInput).toBeVisible();
+      await expect(this.addButton).toBeVisible();
+    });
+  }
+
+  async expectTaskVisible(id: number, taskText: string) {
+    await test.step(`Check that task ${id} is visible`, async () => {
+      await expect(this.taskItemById(id)).toBeVisible();
+      await expect(this.taskTextById(id)).toHaveText(taskText);
+    });
+  }
+
+  async expectTaskNotVisible(id: number) {
+    await test.step(`Check that task ${id} is not visible`, async () => {
+      await expect(this.taskItemById(id)).not.toBeVisible();
+    });
+  }
+
+  async expectNoTaskWasCreated() {
+    await test.step('Check that no task was created', async () => {
+      await expect(this.taskList).not.toBeVisible();
+    });
+  }
+
+  async expectTaskInputEmpty() {
+    await test.step('Check that the task input is empty', async () => {
+      await expect(this.taskInput).toHaveValue('');
+    });
+  }
+
+  async expectCompletedTaskVisible(id: number, taskText: string) {
+    await test.step(`Check that completed task ${id} is visible`, async () => {
+      await expect(this.completedTasksTitle).toBeVisible();
+      await expect(this.completedTaskList).toBeVisible();
+      await expect(this.completedTaskById(id)).toBeVisible();
+      await expect(this.completedTaskTextById(id)).toHaveText(taskText);
+      await expect(this.completedTaskStatusById(id)).toHaveText('Complete');
+    });
+  }
+}

--- a/tests/specs/form.spec.ts
+++ b/tests/specs/form.spec.ts
@@ -1,0 +1,35 @@
+import { test } from '../fixtures/test';
+import {
+  requiredFieldMessages,
+  validRegistrationForms,
+} from '../data/formData';
+import { FormPage } from '../pages/FormPage';
+
+test.describe('Form', { tag: ['@form', '@regression'] }, () => {
+  test('Form required fields', { tag: ['@negative', '@validation'] }, async ({
+    page,
+  }) => {
+    const formPage = new FormPage(page);
+
+    await formPage.goto();
+    await formPage.submit();
+
+    await formPage.expectRequiredFieldMessages(requiredFieldMessages);
+  });
+
+  for (const registrationForm of validRegistrationForms) {
+    test(
+      `Form registration - ${registrationForm.scenario}`,
+      { tag: ['@happy-path', '@data-driven'] },
+      async ({ page }) => {
+        const formPage = new FormPage(page);
+
+        await formPage.goto();
+        await formPage.fillRegistrationForm(registrationForm);
+        await formPage.submit();
+
+        await formPage.expectSuccessPageVisible();
+      },
+    );
+  }
+});

--- a/tests/specs/home.spec.ts
+++ b/tests/specs/home.spec.ts
@@ -1,0 +1,22 @@
+import { test } from '../fixtures/test';
+import { HomePage } from '../pages/HomePage';
+
+test.describe('Home', { tag: ['@home', '@regression'] }, () => {
+  test('Home content visible', async ({ page }) => {
+    const homePage = new HomePage(page);
+
+    await homePage.goto();
+
+    await homePage.expectHomePageVisible();
+    await homePage.expectMainChallengesVisible();
+  });
+
+  test('Home navigate to login', async ({ page }) => {
+    const homePage = new HomePage(page);
+
+    await homePage.goto();
+    await homePage.clickLoginLink();
+
+    await homePage.expectRedirectedToLogin();
+  });
+});

--- a/tests/specs/login.spec.ts
+++ b/tests/specs/login.spec.ts
@@ -1,0 +1,94 @@
+import { test } from '../fixtures/test';
+import {
+  blockedUser,
+  invalidUser,
+  userWithInvalidPassword,
+  validUser,
+} from '../data/users';
+import { LoginPage } from '../pages/LoginPage';
+
+test.describe('Login', { tag: ['@login', '@regression'] }, () => {
+  test('Login form visible', { tag: '@smoke' }, async ({ page }) => {
+    const loginPage = new LoginPage(page);
+
+    await loginPage.goto();
+
+    await loginPage.expectLoginPageVisible();
+  });
+
+  test('Login successful', { tag: '@happy-path' }, async ({ page }) => {
+    const loginPage = new LoginPage(page);
+
+    await loginPage.goto();
+    await loginPage.login(validUser.username, validUser.password);
+
+    await loginPage.expectSuccessfulLoginMessage();
+    await loginPage.expectRedirectedToDashboard();
+  });
+
+  test(
+    'Login wrong password',
+    { tag: ['@negative', '@wrong-password'] },
+    async ({ page }) => {
+      const loginPage = new LoginPage(page);
+
+      await loginPage.goto();
+      await loginPage.login(
+        userWithInvalidPassword.username,
+        userWithInvalidPassword.password,
+      );
+
+      await loginPage.expectInvalidPasswordMessage();
+    },
+  );
+
+  test(
+    'Login blocked user',
+    { tag: ['@negative', '@blocked-user'] },
+    async ({ page }) => {
+      const loginPage = new LoginPage(page);
+
+      await loginPage.goto();
+      await loginPage.login(blockedUser.username, blockedUser.password);
+
+      await loginPage.expectBlockedUserMessage();
+    },
+  );
+
+  test(
+    'Login user not found',
+    { tag: ['@negative', '@user-not-found'] },
+    async ({ page }) => {
+      const loginPage = new LoginPage(page);
+
+      await loginPage.goto();
+      await loginPage.login(invalidUser.username, invalidUser.password);
+
+      await loginPage.expectUserNotFoundMessage();
+    },
+  );
+
+  test(
+    'Login temporary block after 3 wrong passwords',
+    { tag: ['@negative', '@temporary-block'] },
+    async ({ page }) => {
+      const loginPage = new LoginPage(page);
+
+      await loginPage.goto();
+      await loginPage.login(
+        userWithInvalidPassword.username,
+        userWithInvalidPassword.password,
+      );
+      await loginPage.login(
+        userWithInvalidPassword.username,
+        userWithInvalidPassword.password,
+      );
+      await loginPage.login(
+        userWithInvalidPassword.username,
+        userWithInvalidPassword.password,
+      );
+
+      await loginPage.expectTemporaryBlockedMessage();
+    },
+  );
+});

--- a/tests/specs/store-inventory.spec.ts
+++ b/tests/specs/store-inventory.spec.ts
@@ -1,0 +1,48 @@
+import { test } from '../fixtures/test';
+import { newProduct, paymentMethods } from '../data/products';
+import { StorePage } from '../pages/StorePage';
+
+test.describe(
+  'Store inventory checkout flow',
+  { tag: ['@store', '@regression', '@inventory', '@checkout-flow'] },
+  () => {
+    test('Store buy newly created product', { tag: '@happy-path' }, async ({
+      page,
+    }) => {
+      const storePage = new StorePage(page);
+
+      await storePage.goto();
+      await storePage.openInventory();
+      await storePage.expectInventoryVisible();
+      await storePage.createProduct(
+        newProduct.name,
+        newProduct.price,
+        newProduct.quantity,
+      );
+
+      await storePage.openCatalog();
+      await storePage.expectCatalogProductVisibleByName(newProduct.name);
+      await storePage.addProductToCartByName(newProduct.name);
+      await storePage.expectCatalogProductQuantityByName(
+        newProduct.name,
+        newProduct.quantityAfterAddingOne,
+      );
+
+      await storePage.openCart();
+      await storePage.expectProductInCart(0, newProduct.name, '1', newProduct.price);
+      await storePage.expectCartTotal(newProduct.price);
+
+      await storePage.goToPayment();
+      await storePage.selectPaymentMethod(paymentMethods.visa);
+      await storePage.confirmPayment();
+
+      await storePage.expectOrdersVisible();
+      await storePage.expectOrderCreated(
+        0,
+        [newProduct],
+        paymentMethods.visa,
+        newProduct.price,
+      );
+    });
+  },
+);

--- a/tests/specs/store-negative.spec.ts
+++ b/tests/specs/store-negative.spec.ts
@@ -1,0 +1,28 @@
+import { test } from '../fixtures/test';
+import { StorePage } from '../pages/StorePage';
+
+test.describe('Store negative flows', { tag: ['@store', '@regression'] }, () => {
+  test('Store cart empty', { tag: ['@negative', '@cart'] }, async ({
+    page,
+  }) => {
+    const storePage = new StorePage(page);
+
+    await storePage.goto();
+    await storePage.openCart();
+
+    await storePage.expectCartVisible();
+    await storePage.expectCartEmptyMessage();
+  });
+
+  test('Store payment empty', { tag: ['@negative', '@payment'] }, async ({
+    page,
+  }) => {
+    const storePage = new StorePage(page);
+
+    await storePage.goto();
+    await storePage.openPayments();
+
+    await storePage.expectPaymentVisible();
+    await storePage.expectPaymentEmptyMessage();
+  });
+});

--- a/tests/specs/store.spec.ts
+++ b/tests/specs/store.spec.ts
@@ -1,0 +1,103 @@
+import type { BrowserContext, Page } from '@playwright/test';
+import { test } from '../fixtures/test';
+import { checkoutScenarios } from '../data/products';
+import { StorePage } from '../pages/StorePage';
+
+test.describe(
+  'Store checkout flow',
+  { tag: ['@store', '@regression', '@checkout-flow'] },
+  () => {
+    for (const checkoutScenario of checkoutScenarios) {
+      test.describe(checkoutScenario.scenario, () => {
+        test.describe.configure({ mode: 'serial' });
+
+        let context: BrowserContext;
+        let page: Page;
+        let storePage: StorePage;
+
+        test.beforeAll(async ({ browser }) => {
+          context = await browser.newContext();
+          page = await context.newPage();
+          storePage = new StorePage(page);
+        });
+
+        test.afterAll(async () => {
+          await context.close();
+        });
+
+        test('Store flow open catalog', { tag: '@smoke' }, async () => {
+          await storePage.goto();
+          await storePage.expectStorePageVisible();
+          await storePage.openCatalog();
+
+          await storePage.expectCatalogVisible();
+
+          for (const product of checkoutScenario.products) {
+            await storePage.expectCatalogProductVisible(
+              product.index,
+              product.name,
+            );
+          }
+        });
+
+        test('Store flow add products', { tag: '@stock' }, async () => {
+          for (const product of checkoutScenario.products) {
+            await storePage.addProductToCart(product.index);
+
+            await storePage.expectCatalogProductQuantity(
+              product.index,
+              product.quantityAfterAddingOne,
+            );
+          }
+        });
+
+        test('Store flow validate cart', { tag: '@cart' }, async () => {
+          await storePage.openCart();
+
+          await storePage.expectCartVisible();
+
+          for (const [cartIndex, product] of checkoutScenario.products.entries()) {
+            await storePage.expectProductInCart(
+              cartIndex,
+              product.name,
+              '1',
+              product.price,
+            );
+          }
+
+          await storePage.expectCartTotal(checkoutScenario.expectedTotal);
+        });
+
+        test('Store flow go to payment', { tag: '@payment' }, async () => {
+          await storePage.goToPayment();
+
+          await storePage.expectPaymentVisible();
+        });
+
+        test('Store flow select payment method', { tag: '@payment' }, async () => {
+          await storePage.selectPaymentMethod(checkoutScenario.paymentMethod);
+
+          await storePage.expectPaymentMethodSelected(
+            checkoutScenario.paymentMethod,
+          );
+        });
+
+        test(
+          'Store flow confirm order',
+          { tag: ['@happy-path', '@payment'] },
+          async () => {
+            await storePage.confirmPayment();
+
+            await storePage.expectOrdersVisible();
+            await storePage.expectOrderCreated(
+              0,
+              checkoutScenario.products,
+              checkoutScenario.paymentMethod,
+              checkoutScenario.expectedTotal,
+            );
+          },
+        );
+      });
+    }
+  },
+);

--- a/tests/specs/table.spec.ts
+++ b/tests/specs/table.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '../fixtures/test';
+import {
+  characterScenarios,
+  charactersApiUrl,
+  type Character,
+} from '../data/characters';
+import { TablePage } from '../pages/TablePage';
+
+test.describe('Table', { tag: ['@table', '@regression'] }, () => {
+  for (const characterScenario of characterScenarios) {
+    test(
+      `Table ${characterScenario.name} matches API`,
+      { tag: ['@api', '@mock', '@happy-path', '@data-driven'] },
+      async ({ page, request }) => {
+        const tablePage = new TablePage(page);
+
+        const response = await request.get(charactersApiUrl);
+        expect(response.ok()).toBeTruthy();
+
+        const apiCharacters = (await response.json()) as Character[];
+        const expectedCharacter = apiCharacters[characterScenario.index];
+
+        await test.step(
+          `Check API returned "${characterScenario.name}" at position ${
+            characterScenario.index + 1
+          }`,
+          async () => {
+            expect(expectedCharacter.name).toBe(characterScenario.name);
+          },
+        );
+
+        await page.route(charactersApiUrl, async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(apiCharacters),
+          });
+        });
+
+        await tablePage.goto();
+
+        await tablePage.expectTableVisible();
+        await tablePage.expectMainColumnsVisible();
+        await tablePage.expectCharacterVisible(expectedCharacter);
+      },
+    );
+  }
+});

--- a/tests/specs/tasks.spec.ts
+++ b/tests/specs/tasks.spec.ts
@@ -1,0 +1,76 @@
+import { test } from '../fixtures/test';
+import { taskExamples } from '../data/tasks';
+import { TasksPage } from '../pages/TasksPage';
+
+test.describe('Tasks', { tag: ['@tasks', '@regression'] }, () => {
+  test('Tasks page visible', { tag: '@smoke' }, async ({ page }) => {
+    const tasksPage = new TasksPage(page);
+
+    await tasksPage.goto();
+
+    await tasksPage.expectTasksPageVisible();
+  });
+
+  test('Tasks add task', { tag: '@happy-path' }, async ({ page }) => {
+    const tasksPage = new TasksPage(page);
+
+    await tasksPage.goto();
+    await tasksPage.addTask(taskExamples.firstTask);
+
+    await tasksPage.expectTaskVisible(1, taskExamples.firstTask);
+    await tasksPage.expectTaskInputEmpty();
+  });
+
+  test('Tasks empty task not created', { tag: '@negative' }, async ({
+    page,
+  }) => {
+    const tasksPage = new TasksPage(page);
+
+    await tasksPage.goto();
+    await tasksPage.addTask(taskExamples.emptyTask);
+
+    await tasksPage.expectNoTaskWasCreated();
+  });
+
+  test('Tasks edit task', { tag: ['@happy-path', '@edit'] }, async ({
+    page,
+  }) => {
+    const tasksPage = new TasksPage(page);
+
+    await tasksPage.goto();
+    await tasksPage.addTask(taskExamples.firstTask);
+    await tasksPage.editTask(1, taskExamples.editedTask);
+
+    await tasksPage.expectTaskVisible(1, taskExamples.editedTask);
+  });
+
+  test('Tasks complete task', { tag: ['@happy-path', '@complete'] }, async ({
+    page,
+  }) => {
+    const tasksPage = new TasksPage(page);
+
+    await tasksPage.goto();
+    await tasksPage.addTask(taskExamples.firstTask);
+    await tasksPage.completeTask(1);
+
+    await tasksPage.expectTaskNotVisible(1);
+    await tasksPage.expectCompletedTaskVisible(1, taskExamples.firstTask);
+  });
+
+  test(
+    'Tasks completed list visible',
+    { tag: ['@happy-path', '@complete'] },
+    async ({ page }) => {
+      const tasksPage = new TasksPage(page);
+
+      await tasksPage.goto();
+      await tasksPage.addTask(taskExamples.firstTask);
+      await tasksPage.addTask(taskExamples.secondTask);
+      await tasksPage.completeTask(1);
+      await tasksPage.completeTask(2);
+
+      await tasksPage.expectCompletedTaskVisible(1, taskExamples.firstTask);
+      await tasksPage.expectCompletedTaskVisible(2, taskExamples.secondTask);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Adds a Playwright test suite using TypeScript and Page Object Model, structured for teaching automated testing best practices.

The suite covers the main application flows with clear specs, reusable test data, page objects, tags, and `test.step` reporting.

## What was added

- Playwright configuration with the deployed app as `baseURL`
- GitHub Actions workflow for Playwright tests
- Test scripts:
  - `npm run test:e2e`
  - `npm run test:e2e:ui`
- Organized test structure:
  - `tests/specs`
  - `tests/pages`
  - `tests/data`
  - `tests/fixtures`

## Covered flows

### Home

- Home content visibility
- Navigation to login

### Login

- Login form visibility
- Successful login
- Wrong password
- Blocked user
- User not found
- Temporary block after 3 wrong attempts

### Form

- Required field validations
- Data-driven valid registrations with multiple datasets

### Tasks

- Page visibility
- Add task
- Prevent empty task creation
- Edit task
- Complete task
- Validate completed task list

### Store

- Serial checkout flow by payment method
- Data-driven checkout scenarios with one or multiple products
- All payment methods covered:
  - MBWay
  - Klarna
  - Multibanco
  - PayPal
  - Visa
- Empty cart validation
- Empty payment page validation
- Create a new product in inventory and purchase it

### Table

- Calls the external Harry Potter API with Playwright `request`
- Mocks the frontend API call with `page.route`
- Data-driven validation for the first 10 characters
- Test names include the character being validated

## Notes

- Tests use Page Object Model with the internal order:
  - fixed locators
  - dynamic locators
  - actions
  - asserts
- Actions and assertions include `test.step` for readable reports.
- Tags were added by feature and scenario type, such as:
  - `@login`
  - `@form`
  - `@tasks`
  - `@store`
  - `@table`
  - `@regression`
  - `@negative`
  - `@happy-path`
  - `@data-driven`

## Validation

Executed successfully:

```bash
npm run test:e2e -- --project=chromium --grep @regression